### PR TITLE
Don't assume that the "DOS Stub" is (at least) 0x80 bytes in size. In…

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Contents
 
 This is a simple tool to remove the "Rich" header from binaries (EXE or DLL files) created by M$ development tools.
 
-For more details on that ***undocumented*** header, please see here:
+For more details on that ***undocumented*** header, please see here:  
 https://www.ntcore.com/files/richsign.htm
 
 

--- a/src/version.h
+++ b/src/version.h
@@ -16,7 +16,7 @@
 #define VER_RCHHDRRSR_MAJOR      1
 #define VER_RCHHDRRSR_MINOR_HI   0
 #define VER_RCHHDRRSR_MINOR_LO   1
-#define VER_RCHHDRRSR_PATCH      2
+#define VER_RCHHDRRSR_PATCH      3
 
 ///////////////////////////////////////////////////////////////////////////////
 // Helper macros (aka: having fun with the C pre-processor)


### PR DESCRIPTION
…stead start searching for the "Rich" header at address 0x40, i.e. right after the MZ header.

This should make Rich-Header Eraser work with EXE/DLL files that have been built with a "custom" stub program (MSVC option "/STUB").
Also fixed a bug in computing the address of the PE header. This bug did *not* normally cause a problem, because the two most significant byte are usually zero.